### PR TITLE
PRED-003: add fastest lap prediction to prediction forms and API

### DIFF
--- a/src/app/api/predictions/[id]/route.ts
+++ b/src/app/api/predictions/[id]/route.ts
@@ -46,6 +46,7 @@ export async function GET(
             id: prediction.id,
             raceId: prediction.raceId,
             polePosition: prediction.polePositionPrediction || '',
+            fastestLap: prediction.fastestLapPrediction || '',
             raceWinner: positions[0] || '',
             secondPlace: positions[1] || '',
             thirdPlace: positions[2] || '',
@@ -113,7 +114,7 @@ export async function PUT(
             data: {
                 polePositionPrediction: body.polePositionPrediction || null,
                 positions: positions,
-                fastestLapPrediction: null, // Not implemented yet
+                fastestLapPrediction: body.fastestLapPrediction || null,
                 sprintPositions: sprintPositions,
                 sprintPolePrediction: body.sprintPolePrediction || null,
                 updatedAt: new Date(),

--- a/src/app/api/predictions/route.ts
+++ b/src/app/api/predictions/route.ts
@@ -85,11 +85,11 @@ export async function POST(request: NextRequest) {
         }
 
         const userId = session.user.id;
-        const body = await request.json();
-        const { raceId, positions, polePositionPrediction, sprintPolePrediction, sprintPositions } = body;
+    const body = await request.json();
+    const { raceId, positions, polePositionPrediction, fastestLapPrediction, sprintPolePrediction, sprintPositions } = body;
 
         // Validate data
-        if (!raceId || !positions || !Array.isArray(positions)) {
+    if (!raceId || !positions || !Array.isArray(positions)) {
             return NextResponse.json(
                 { error: 'Invalid data. raceId and positions (array) are required' },
                 { status: 400 }
@@ -127,11 +127,12 @@ export async function POST(request: NextRequest) {
 
         if (existingPrediction) {
             // Update existing prediction
-            prediction = await prisma.prediction.update({
+        prediction = await prisma.prediction.update({
                 where: { id: existingPrediction.id },
                 data: {
                     positions,
                     polePositionPrediction: polePositionPrediction || null,
+            fastestLapPrediction: fastestLapPrediction || null,
                     sprintPolePrediction: sprintPolePrediction || null,
                     sprintPositions: sprintPositions || null,
                     updatedAt: new Date(),
@@ -145,6 +146,7 @@ export async function POST(request: NextRequest) {
                     raceId,
                     positions,
                     polePositionPrediction: polePositionPrediction || null,
+            fastestLapPrediction: fastestLapPrediction || null,
                     sprintPolePrediction: sprintPolePrediction || null,
                     sprintPositions: sprintPositions || null,
                 },

--- a/src/components/predictions/prediction-form.tsx
+++ b/src/components/predictions/prediction-form.tsx
@@ -16,6 +16,7 @@ interface PredictionFormProps {
 
 interface FormData {
     polePosition: string;
+    fastestLap: string;
     raceWinner: string;
     secondPlace: string;
     thirdPlace: string;
@@ -30,6 +31,7 @@ interface FormData {
 export default function PredictionFormComponent({ race, drivers, prediction, onPredictionUpdate }: PredictionFormProps) {
     const [formData, setFormData] = useState<FormData>({
         polePosition: '',
+        fastestLap: '',
         raceWinner: '',
         secondPlace: '',
         thirdPlace: '',
@@ -43,6 +45,7 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
     
     const [originalFormData, setOriginalFormData] = useState<FormData>({
         polePosition: '',
+        fastestLap: '',
         raceWinner: '',
         secondPlace: '',
         thirdPlace: '',
@@ -62,6 +65,7 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
         if (prediction) {
             const newFormData = {
                 polePosition: prediction.polePosition || '',
+                fastestLap: prediction.fastestLap || '',
                 raceWinner: prediction.raceWinner || '',
                 secondPlace: prediction.secondPlace || '',
                 thirdPlace: prediction.thirdPlace || '',
@@ -78,6 +82,7 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
             // Reset to empty state if no prediction
             const emptyFormData = {
                 polePosition: '',
+                fastestLap: '',
                 raceWinner: '',
                 secondPlace: '',
                 thirdPlace: '',
@@ -101,7 +106,7 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
     };
 
     const isFormValid = () => {
-        const requiredFields = ['polePosition', 'raceWinner', 'secondPlace', 'thirdPlace', 'fourthPlace', 'fifthPlace'];
+    const requiredFields = ['polePosition', 'fastestLap', 'raceWinner', 'secondPlace', 'thirdPlace', 'fourthPlace', 'fifthPlace'];
         const raceFields = requiredFields.every(field => formData[field as keyof FormData] !== '');
         
         if (race.hasSprint) {
@@ -194,6 +199,7 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
         try {
             const predictionData: PredictionForm = {
                 polePosition: formData.polePosition,
+                fastestLap: formData.fastestLap,
                 raceWinner: formData.raceWinner,
                 secondPlace: formData.secondPlace,
                 thirdPlace: formData.thirdPlace,
@@ -280,6 +286,32 @@ export default function PredictionFormComponent({ race, drivers, prediction, onP
                                 onSelectionChange={(keys) => {
                                     const selectedKey = Array.from(keys)[0] as string;
                                     handleSelectChange('polePosition', selectedKey || '');
+                                }}
+                                isRequired
+                                isDisabled={isDisabled}
+                            >
+                                {drivers.map((driver) => (
+                                    <SelectItem 
+                                        key={driver.id}
+                                        textValue={`#${driver.number} ${driver.fullname}`}
+                                    >
+                                        #{driver.number} {driver.fullname}
+                                    </SelectItem>
+                                ))}
+                            </Select>
+                        </div>
+
+                        {/* Fastest Lap */}
+                        <div className="mb-4">
+                            <Select
+                                id="fastest-lap"
+                                name="fastestLap"
+                                label="Fastest Lap"
+                                placeholder="Select driver for fastest lap"
+                                selectedKeys={formData.fastestLap ? [formData.fastestLap] : []}
+                                onSelectionChange={(keys) => {
+                                    const selectedKey = Array.from(keys)[0] as string;
+                                    handleSelectChange('fastestLap', selectedKey || '');
                                 }}
                                 isRequired
                                 isDisabled={isDisabled}

--- a/src/services/predictions.ts
+++ b/src/services/predictions.ts
@@ -5,6 +5,7 @@ export interface Prediction {
     raceId: string;
     userId: string;
     polePosition: string;
+    fastestLap?: string;
     raceWinner: string;
     secondPlace: string;
     thirdPlace: string;
@@ -21,6 +22,7 @@ export interface Prediction {
 
 export interface PredictionForm {
     polePosition: string;
+    fastestLap: string;
     raceWinner: string;
     secondPlace: string;
     thirdPlace: string;
@@ -36,6 +38,7 @@ interface CreatePredictionRequest {
     raceId: string;
     positions: string[];
     polePositionPrediction: string;
+    fastestLapPrediction: string;
     sprintPolePrediction?: string;
     sprintPositions?: string[];
 }
@@ -67,6 +70,7 @@ export async function getUserPrediction(raceId: string) {
             raceId: data.raceId,
             userId: data.userId,
             polePosition: data.polePosition,
+            fastestLap: data.fastestLap,
             raceWinner: data.raceWinner,
             secondPlace: data.secondPlace,
             thirdPlace: data.thirdPlace,
@@ -105,6 +109,7 @@ export async function createPrediction(raceId: string, prediction: PredictionFor
             raceId,
             positions,
             polePositionPrediction: prediction.polePosition,
+            fastestLapPrediction: prediction.fastestLap,
         };
 
         // Add sprint data if present and complete
@@ -141,6 +146,7 @@ export async function createPrediction(raceId: string, prediction: PredictionFor
             raceId: result.raceId,
             userId: result.userId,
             polePosition: requestBody.polePositionPrediction,
+            fastestLap: requestBody.fastestLapPrediction,
             raceWinner: positions[0],
             secondPlace: positions[1],
             thirdPlace: positions[2],
@@ -173,11 +179,13 @@ export async function updatePrediction(raceId: string, prediction: PredictionFor
 
         const requestBody: {
             polePositionPrediction: string;
+            fastestLapPrediction: string;
             positions: string[];
             sprintPolePrediction?: string;
             sprintPositions?: string[];
         } = {
             polePositionPrediction: prediction.polePosition,
+            fastestLapPrediction: prediction.fastestLap,
             positions: positions,
         };
 
@@ -215,6 +223,7 @@ export async function updatePrediction(raceId: string, prediction: PredictionFor
             raceId: result.raceId,
             userId: result.userId,
             polePosition: requestBody.polePositionPrediction,
+            fastestLap: requestBody.fastestLapPrediction,
             raceWinner: positions[0],
             secondPlace: positions[1],
             thirdPlace: positions[2],

--- a/src/services/predictions.ts
+++ b/src/services/predictions.ts
@@ -5,7 +5,7 @@ export interface Prediction {
     raceId: string;
     userId: string;
     polePosition: string;
-    fastestLap?: string;
+    fastestLap: string;
     raceWinner: string;
     secondPlace: string;
     thirdPlace: string;


### PR DESCRIPTION
**PRED-003: Fastest Lap Predictions**
- **As a** user **I want to** predict fastest lap winners **so that** I can earn additional points
- **Acceptance Criteria:**
  - Add fastest lap prediction field to forms
  - Include fastest lap in scoring calculations
  - Display fastest lap predictions in race overview
- **Technical Tasks:**
  - Update prediction form UI
  - Modify database schema if needed
  - Update scoring calculation logic